### PR TITLE
Add an example of a custom view to the application

### DIFF
--- a/app/src/main/java/org/usfirst/frc/team4911/scouting/PitActivity.java
+++ b/app/src/main/java/org/usfirst/frc/team4911/scouting/PitActivity.java
@@ -3,12 +3,21 @@ package org.usfirst.frc.team4911.scouting;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
-// Someday (soon?) this will allow us to take pictures. Right now it's just a stub.
+import org.usfirst.frc.team4911.scouting.datamodel.MatchData;
+import org.usfirst.frc.team4911.scouting.ui.ExampleCustomView;
+
+// Someday (soon?) this will allow us to take pictures. Right now it's just a stub (with an custom example view!)
 public class PitActivity extends AppCompatActivity {
+
+    ExampleCustomView exampleView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_pit);
+
+        // This is where you extract the custom view, and then initialize whatever data you need there
+        exampleView = (ExampleCustomView) findViewById(R.id.example_view);
+        exampleView.setMatchData(new MatchData());
     }
 }

--- a/app/src/main/java/org/usfirst/frc/team4911/scouting/ui/ExampleCustomView.java
+++ b/app/src/main/java/org/usfirst/frc/team4911/scouting/ui/ExampleCustomView.java
@@ -1,0 +1,102 @@
+package org.usfirst.frc.team4911.scouting.ui;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+
+import org.usfirst.frc.team4911.scouting.R;
+import org.usfirst.frc.team4911.scouting.datamodel.MatchData;
+
+
+public class ExampleCustomView extends LinearLayout {
+
+    private Context context;
+    private int defaultValue;
+    private EditText counter;
+
+    // This is added here as an example of the data model you could be writing to, this could
+    // very well be any generic data container (teleop, auto, end game, etc)
+    private MatchData matchData;
+
+    // This constructor is called implicitly when the view is created. The context is essentially
+    // the activity from which this was created (so you can use it for getting resources or other
+    // things). The AttributeSet is the set of attributes that are defined in the XML layout, and
+    // are used to configure how the view looks
+    public ExampleCustomView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+
+        // Initialize the context object for use later
+        this.context = context;
+
+        // Set up all of the layouts
+        setupLayout(attrs);
+    }
+
+    private void setupLayout(AttributeSet attrs) {
+        // Inflate the XML layout
+        LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        inflater.inflate(R.layout.example_layout, this);
+
+        // Initialize all of the other view objects now that the layout is inflated
+        counter = (EditText) findViewById(R.id.counter_edit_text);
+        Button negativeButton = (Button) findViewById(R.id.negative_button);
+        Button positiveButton = (Button) findViewById(R.id.positive_button);
+        Button saveButton = (Button) findViewById(R.id.save_button);
+
+        // Set up the click listener on the negative button, adding validation to make sure it doesn't
+        // go below zero
+        negativeButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                int currentValue = Integer.valueOf(counter.getText().toString());
+                if (currentValue > 0) {
+                    currentValue--;
+                }
+                counter.setText(String.valueOf(currentValue));
+            }
+        });
+
+        // Set up the click listener on the positive button
+        positiveButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                counter.setText(String.valueOf(Integer.valueOf(counter.getText().toString()) + 1));
+            }
+        });
+
+        // Set up the click listener on the save button
+        saveButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                // This is where we would extract the data from the view (such as the counter value) and
+                // write it into the backend data model. This could include some validation and potentially popup
+                // a toast.
+                //
+                // If the data successfully writes, we can then reset the view back to the defaultValue
+                counter.setText(String.valueOf(defaultValue));
+            }
+        });
+
+        // Convert the attribute set to a typed array
+        TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable.ExampleCustomView, 0, 0);
+
+        // Retrieve the values from the typed array, using them however you want. In this case, we're
+        // just using it to initialize the view so we can use it locally
+        try {
+            defaultValue = a.getInt(R.styleable.ExampleCustomView_defaultValue, 0);
+            counter.setText(String.valueOf(defaultValue));
+        } finally {
+            a.recycle();
+        }
+    }
+
+    // This is used to pass in the data object to which you're writing
+    public void setMatchData(MatchData matchData) {
+        this.matchData = matchData;
+    }
+}

--- a/app/src/main/res/layout/activity_pit.xml
+++ b/app/src/main/res/layout/activity_pit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/activity_pit"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -15,4 +16,10 @@
         android:gravity="start"
         android:text="@string/header_pit"
         android:textSize="25sp" />
+
+    <org.usfirst.frc.team4911.scouting.ui.ExampleCustomView
+        android:id="@+id/example_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:defaultValue = "5"/>
 </LinearLayout>

--- a/app/src/main/res/layout/example_layout.xml
+++ b/app/src/main/res/layout/example_layout.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/negative_button"
+            android:layout_width="50dp"
+            android:layout_height="wrap_content"
+            android:text="-"/>
+
+        <EditText
+            android:id="@+id/counter_edit_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:layout_weight="1"/>
+
+        <Button
+            android:id="@+id/positive_button"
+            android:layout_width="50dp"
+            android:layout_height="wrap_content"
+            android:text="+"/>
+
+    </LinearLayout>
+
+    <Button
+        android:id="@+id/save_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Save"/>
+
+
+</LinearLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -29,4 +29,8 @@
     <declare-styleable name="CircleImageView">
         <attr name="name" format="string" />
     </declare-styleable>
+
+    <declare-styleable name="ExampleCustomView">
+        <attr name="defaultValue" format="integer" />
+    </declare-styleable>
 </resources>


### PR DESCRIPTION
This goes through and adds a custom view to the app, currently showing on the PitActivity. This view shows how you can package a custom UI element that is defined in an XML layout, define custom attributes for that XML layout, and process information within that view.

This makes it easier to incorporate the same UI elements on multiple screens, packaging all of the logic needed for that UI element in a single place.

If you have any questions let me know! I tried to put this somewhere out of the way if you do choose to merge this in, otherwise it's fine just sitting here as an example.

@AnneGR @johansu 